### PR TITLE
High School Serializer Bug Fix

### DIFF
--- a/high_school/models.py
+++ b/high_school/models.py
@@ -11,7 +11,7 @@ class HighSchool(models.Model):
     location = models.CharField(max_length=100)
     phone_number = models.CharField(max_length=15, blank=False, null=False)
     school_email = models.EmailField(blank=False, null=False)
-    website = models.CharField(max_length=50)
+    website = models.CharField(max_length=70)
     total_students = models.IntegerField()
     start_time = models.CharField(max_length=6)
     end_time = models.CharField(max_length=6)

--- a/high_school/views.py
+++ b/high_school/views.py
@@ -19,6 +19,31 @@ def save_highschool_data(request, user_type):
                 ApiInfo.API_RESOURCE, select=ApiInfo.LOCAL_FIELD_LIST, limit=limit
             )
             serializer = HighSchoolSerializer(data=results, many=True)
+            for x in range(limit):
+                # for testing purposes, we should not be using actual high school emails
+                # all school emails are replaced with Patryk's email for future implementation of
+                # supervisor email being taken directly from the school.
+                serializer.initial_data[x]["school_email"] = "pp2224@nyu.edu"
+                try:
+                    # check if there is a start time in the school info
+                    # if it is there then get the substring that ends it after "am"
+                    # some fields have text after the time that is not necessary
+                    if serializer.initial_data[x]["start_time"]:
+                        am_loc = serializer.initial_data[x]["start_time"].find("am")
+                        serializer.initial_data[x]["start_time"] = serializer.initial_data[x]["start_time"][:am_loc+2]
+                except KeyError:
+                    # if there is no start time provided in the info set it to N/A
+                    serializer.initial_data[x]["start_time"] = "N/A"
+                try:
+                    # check if there is a end time in the school info
+                    # if it is there then get the substring that ends it after "pm"
+                    # some fields have text after the time that is not necessary
+                    if serializer.initial_data[x]["end_time"]:
+                        pm_loc = serializer.initial_data[x]["end_time"].find("pm")
+                        serializer.initial_data[x]["end_time"] = serializer.initial_data[x]["end_time"][:pm_loc+2]
+                except KeyError:
+                    # if there is no end time provided in the info set it to N/A
+                    serializer.initial_data[x]["end_time"] = "N/A"
             if serializer.is_valid():
                 response = serializer.save()
                 return render(request, "high_school/index.html", {"response": response})


### PR DESCRIPTION
- updated the data that goes into the database via serializers
- all school emails have been updated to be my email (later on high school emails will be used as the supervisor email so this is prep for that)
- high school website length has been increased
- start time and end time might be longer than 6 characters due to extra characters after "am" or "pm" 
          - updated so that start time is only taken to include am, ex: 8:30am
          - updated so that end time is only taken to include pm, ex: 3:30pm
          - any characters after am or pm are ignored
- there is a few cases where start time and end time are not included. If it is not then the values are set to "N/A" 
- now all 427 schools can be saved