### PR TITLE
All schools tab - bug fixes

### DIFF
--- a/high_school/templates/high_school/broken.html
+++ b/high_school/templates/high_school/broken.html
@@ -34,7 +34,7 @@
             </a>
         </div>
         {#        default for empty list#}
-    {% else %}
+    {% elif empty_list == 1 %}
         <div class="no-school-placeholder">
             <div style="font-size: 18px;">
                     <span class="mb-3" style="font-size: 48px">

--- a/high_school/templates/high_school/index.html
+++ b/high_school/templates/high_school/index.html
@@ -162,7 +162,6 @@
                 url: url,
                 type: "POST",
                 success: function (data) {
-                    console.log("success " + data);
                     let i_tag = school_fav_btn.find("i");
                     i_tag.removeClass("fa-heart-o");
                     i_tag.removeClass("fa-heart");
@@ -175,7 +174,6 @@
                     }
                 },
                 error: function (data) {
-                    console.log("error")
                 }
             });
         });

--- a/high_school/templates/high_school/index.html
+++ b/high_school/templates/high_school/index.html
@@ -42,6 +42,16 @@
                 </div>
             </div>
         </div>
+        <div class="toast" style="position: absolute; top: 15%; right: 43%;">
+            <div class="toast-header">
+                <strong class="mr-auto text-primary">Info</strong>
+                <button type="button" class="ml-2 mb-1 close" data-dismiss="toast">&times;
+                </button>
+            </div>
+            <div class="toast-body">
+                <span></span>
+            </div>
+        </div>
     </div>
     </body>
     <script>
@@ -151,50 +161,36 @@
         {#to toggle fav high school for user#}
         $(".school-fav-btn").click(function (e) {
             e.preventDefault();
-            let form = $(this).find("form");
-            let school_dbn = form.attr("id").split("_")[1];
-            let is_fav = form.find("input.with-font").attr("checked") ? 1 : 0;
+            let school_fav_btn = $(this);
+            let school_dbn = $(this).attr("dbn_value");
+            let is_fav = parseInt($(this).attr("is_fav"));
             is_fav = is_fav === 1 ? 0 : 1;
+            school_fav_btn.attr("is_fav", is_fav);
             let url = "{% url 'dashboard:high_school:toggle_fav' 'school_dbn' '0000' %}";
             url = url.replace('school_dbn', school_dbn);
             url = url.replace('0000', "" + is_fav);
-            {% comment %}form.submit(function () {
-                $.ajax({
-                    url: url,
-                    type: "POST",
-                    data: {
-                        csrfmiddlewaretoken:form.find('input[name=csrfmiddlewaretoken]').val(),
-                    },
-                    success: function (data) {
-                        console.log("success")
-                    },
-                    error: function (data) {
-                        console.log("error")
-                    }
-                });
-                return true;
-            });{% endcomment %}
-            {#$.ajax(url);#}
+            let is_fav_on = "{{ request.GET.is_fav_on }}";
             $.ajax({
                 url: url,
                 type: "POST",
-                data: {
-                    csrfmiddlewaretoken:form.find('input[name=csrfmiddlewaretoken]').val(),
-                },
                 success: function (data) {
-                    console.log("success")
+                    console.log("success " + data);
+                    let i_tag = school_fav_btn.find("i");
+                    i_tag.removeClass("fa-heart-o");
+                    i_tag.removeClass("fa-heart");
+                    i_tag.addClass(is_fav ? "fa-heart" : "fa-heart-o");
+                    if (is_fav_on) {
+                        show_toast("The page will reload in 5 seconds", true);
+                        setTimeout(function () {
+                            window.location.reload();
+                        }, 5000);
+                    }
                 },
                 error: function (data) {
                     console.log("error")
                 }
             });
-            $(this).attr("is_fav", is_fav);
-            let i_tag = $(this).find("i");
-            i_tag.removeClass("fa-heart-o");
-            i_tag.removeClass("fa-heart");
-            i_tag.addClass(is_fav ? "fa-heart" : "fa-heart-o");
-        })
-        ;
+        });
         {# school overview program card functions #}
         let toggle_program_icon = function (show_plus) {
             let i_tag = $("#program_toggle_icon");
@@ -225,7 +221,14 @@
         };
         $('#program-select').on('change', function () {
             toggle_selected_program($(this).val())
-        })
+        });
+        let show_toast = function (message) {
+            $(".toast-body span").text(message);
+            $('.toast').css({'opacity': 1});
+            setTimeout(function () {
+                $('.toast').css({'opacity': 0});
+            }, 3000)
+        };
     </script>
     </html>
 

--- a/high_school/templates/high_school/index.html
+++ b/high_school/templates/high_school/index.html
@@ -151,15 +151,50 @@
         {#to toggle fav high school for user#}
         $(".school-fav-btn").click(function (e) {
             e.preventDefault();
-            let school_dbn = $(this).attr("dbn_value");
-            let is_fav = parseInt($(this).attr("is_fav"));
+            let form = $(this).find("form");
+            let school_dbn = form.attr("id").split("_")[1];
+            let is_fav = form.find("input.with-font").attr("checked") ? 1 : 0;
             is_fav = is_fav === 1 ? 0 : 1;
-            $(this).attr("is_fav", is_fav);
             let url = "{% url 'dashboard:high_school:toggle_fav' 'school_dbn' '0000' %}";
             url = url.replace('school_dbn', school_dbn);
             url = url.replace('0000', "" + is_fav);
-            window.location.href = url;
-        });
+            {% comment %}form.submit(function () {
+                $.ajax({
+                    url: url,
+                    type: "POST",
+                    data: {
+                        csrfmiddlewaretoken:form.find('input[name=csrfmiddlewaretoken]').val(),
+                    },
+                    success: function (data) {
+                        console.log("success")
+                    },
+                    error: function (data) {
+                        console.log("error")
+                    }
+                });
+                return true;
+            });{% endcomment %}
+            {#$.ajax(url);#}
+            $.ajax({
+                url: url,
+                type: "POST",
+                data: {
+                    csrfmiddlewaretoken:form.find('input[name=csrfmiddlewaretoken]').val(),
+                },
+                success: function (data) {
+                    console.log("success")
+                },
+                error: function (data) {
+                    console.log("error")
+                }
+            });
+            $(this).attr("is_fav", is_fav);
+            let i_tag = $(this).find("i");
+            i_tag.removeClass("fa-heart-o");
+            i_tag.removeClass("fa-heart");
+            i_tag.addClass(is_fav ? "fa-heart" : "fa-heart-o");
+        })
+        ;
         {# school overview program card functions #}
         let toggle_program_icon = function (show_plus) {
             let i_tag = $("#program_toggle_icon");
@@ -184,9 +219,9 @@
         $('.collapse').on('show.bs.collapse', function () {
             toggle_program_icon(false)
         });
-        let toggle_selected_program = function(selected_option){
-           $(".program-desc-div").hide();
-           $("#"+selected_option+"_div").show()
+        let toggle_selected_program = function (selected_option) {
+            $(".program-desc-div").hide();
+            $("#" + selected_option + "_div").show()
         };
         $('#program-select').on('change', function () {
             toggle_selected_program($(this).val())

--- a/high_school/templates/high_school/index.html
+++ b/high_school/templates/high_school/index.html
@@ -55,19 +55,7 @@
     </div>
     </body>
     <script>
-        {#         for school list filter#}
-        $(".filter-btn").click(function (e) {
-            let high_school_div = $(".high-school-filter-div");
-            let is_div_visible = high_school_div.hasClass("active");
-            if (!is_div_visible) {
-                high_school_div.addClass("active");
-                high_school_div.show()
-            } else {
-                high_school_div.removeClass("active");
-                high_school_div.hide()
-            }
-        });
-
+        let should_reset_filters = true;
         {# for restricting page numbers in pagination #}
 
         function getPageList(totalPages, page, maxLength) {
@@ -215,12 +203,10 @@
         $('.collapse').on('show.bs.collapse', function () {
             toggle_program_icon(false)
         });
-        let toggle_selected_program = function (selected_option) {
-            $(".program-desc-div").hide();
-            $("#" + selected_option + "_div").show()
-        };
         $('#program-select').on('change', function () {
-            toggle_selected_program($(this).val())
+            let selected_option = $(this).val();
+            $(".program-desc-div").hide();
+            $("#" + selected_option + "_div").show();
         });
         let show_toast = function (message) {
             $(".toast-body span").text(message);
@@ -229,6 +215,81 @@
                 $('.toast').css({'opacity': 0});
             }, 3000)
         };
+        {#         for school list filter#}
+        let toggle_filter_div = function (show) {
+            let high_school_div = $(".high-school-filter-div");
+            if (show) {
+                high_school_div.addClass("active");
+                high_school_div.show();
+                $(".filter-info-div").hide();
+                $(".filter-action-div").show();
+            } else {
+                high_school_div.removeClass("active");
+                high_school_div.hide();
+                $(".filter-action-div").hide();
+                $(".filter-info-div").show();
+            }
+        };
+        $(".filter-info-div").click(function (e) {
+            toggle_filter_div(true);
+        });
+        let reset_filters = function () {
+            if (should_reset_filters) {
+                $(".high-school-filter-div .form-group input[type=checkbox]:checked").each(function () {
+                    $(this).prop("checked", false);
+                });
+                {% for boro_filter in search_filter_params.borough %}
+                    $(".form-group #{{ boro_filter }}").prop("checked", true);
+                {% endfor %}
+            }
+        };
+        $(".filter-action").click(function () {
+            let elem_class = $(this).attr("class");
+            if (elem_class.indexOf("apply-filters") !== -1) {
+                should_reset_filters = false;
+                $("#search_filter_form").submit();
+            } else {
+                reset_filters();
+            }
+            toggle_filter_div(false);
+        });
+        $(function () {
+            let search_form_submit = document.search_filter_form.submit;
+            document.search_filter_form.submit = function () {
+                reset_filters();
+                search_form_submit.apply(document.search_filter_form);
+                return false;
+            };
+        });
+        $('#search_filter_form').keydown(function (e) {
+            let key = e.which;
+            if (key === 13) {
+                e.preventDefault();
+                $('#search_filter_form').submit();
+                return false;
+            }
+            return true;
+        });
+        $(".high-school-filter-div .form-group input[type=checkbox]").click(function () {
+            let _id = $(this).attr("id");
+            let checked_state = $(this).prop("checked");
+            if (_id === "loc_all") {
+                $(".high-school-filter-div .form-group input[type=checkbox]:checked").each(function () {
+                    $(this).prop("checked", false);
+                });
+                $(this).prop("checked", true);
+            } else {
+                if (checked_state) {
+                    $(".all_boroughs input[type=checkbox]").prop("checked", false);
+                    $(this).prop("checked", true)
+                } else {
+                    let checked_count = $(".individual_boroughs input[type=checkbox]:checked").length;
+                    if (checked_count === 0) {
+                        $(".all_boroughs input[type=checkbox]").prop("checked", true);
+                    }
+                }
+            }
+        });
     </script>
     </html>
 

--- a/high_school/templates/high_school/school_list.html
+++ b/high_school/templates/high_school/school_list.html
@@ -28,8 +28,11 @@
                         </div>
                     </div>
                     <div>
+                        <div class="high-school-fav-div {% if not request.GET.is_fav_on or request.GET.is_fav_on == "0" %} hide {% endif %}">
+                            <span>These are your favorite schools...</span>
+                        </div>
                         <div class="high-school-filter-div">
-                            <p class="mb-1">Filter using boroughs</p>
+                            <p class="mb-1">Filtered using boroughs</p>
                             <div class="form-group">
                                 <div class="custom-control custom-checkbox">
                                     <input type="checkbox" class="custom-control-input"
@@ -73,9 +76,6 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="high-school-fav-div {% if not request.GET.is_fav_on or request.GET.is_fav_on == "0" %} hide-fav {% endif %}">
-                            <span>These are your favorite schools...</span>
-                        </div>
                     </div>
                 </form>
             </div>
@@ -91,18 +91,14 @@
                 {% endwith %}
             <div class="d-flex w-100 justify-content-between mb-2">
                 <h4 class="mb-1" style="width: 75%">{{ school.school_name }}</h4>
-                <div class="school-fav-btn">
-                    <form id="favform_{{ school.dbn }}" name="favform_{{ school.dbn }}"
-                          method="POST">
-                        {% csrf_token %}
-                        <label>
-                            <input name="school_fav_on" type="checkbox" class="with-font hide"
-                                   {% if school in fav_schools %}checked=""{% endif %}/>
-                            <i {% if school in fav_schools %} class="fa fa-heart" {% else %}
-                                                              class="fa fa-heart-o"{% endif %}>
-                            </i>
-                        </label>
-                    </form>
+                <div>
+                    <span class="school-fav-btn" dbn_value="{{ school.dbn }}"
+                            {% if school in fav_schools %}
+                          is_fav="1" {% else %} is_fav="0" {% endif %}
+                          style="font-size: 18px; padding: 4px;">
+                        <i{% if school in fav_schools %} class="fa fa-heart"{% else %}
+                                                         class="fa fa-heart-o" {% endif %}></i>
+                    </span>
                 </div>
             </div>
             <div class="d-flex w-100 justify-content-between mb-2">

--- a/high_school/templates/high_school/school_list.html
+++ b/high_school/templates/high_school/school_list.html
@@ -8,7 +8,7 @@
                         <div class="search-div">
                         <span>
                             <input class="search-input" type='text' name='query'
-                                   {% if request.GET.query %}value="{{ request.GET.query }}"
+                                   {% if search_filter_params.query %}value="{{ request.GET.query }}"
                                    {% endif %} placeholder="Search for your school">
                             <span onclick="search_filter_form.submit();" class="search-btn">
                                 <i class="fa fa-search mr-2"></i>
@@ -16,13 +16,23 @@
                         </span>
                         </div>
                         <div class="filters-div">
-                            <span class="filter-btn"><i class="fa fa-filter"></i></span>
-                            <label class="fav-btn">
+                            <div class="filter-btn" title="Show applied filters" style="border-right: 2px solid slategray;">
+                                <div class="filter-info-div">
+                                    <span><i class="fa fa-filter"></i></span>
+                                    <sub>{{ search_filter_params.filter_count }}</sub>
+                                </div>
+                                <div class="filter-action-div" style="display: none;">
+                                    <span class="filter-action apply-filters mr-2" title="Apply changes"><i class="fa fa-check-circle"></i></span>
+                                    <span class="filter-action cancel-filters mr-2" title="Discard changes"><i class="fa fa-times-circle"></i></span>
+                                </div>
+                            </div>
+                            <label class="fav-btn ml-2 mb-0" title="{% if search_filter_params.is_fav_on %}Hide{% else %}Show{% endif %} favorites">
                                 <input name="is_fav_on" type="checkbox" class="with-font hide"
-                                       {% if request.GET.is_fav_on %}checked=""{% endif %}
+                                       {% if search_filter_params.is_fav_on %}checked=""{% endif %}
                                        onchange="search_filter_form.submit();"/>
-                                <i {% if request.GET.is_fav_on %} class="fa fa-heart" {% else %}
-                                                                  class="fa fa-heart-o"{% endif %}>
+                                <i {% if search_filter_params.is_fav_on %}
+                                    class="fa fa-heart" {% else %}
+                                    class="fa fa-heart-o"{% endif %}>
                                 </i>
                             </label>
                         </div>
@@ -33,44 +43,54 @@
                         </div>
                         <div class="high-school-filter-div">
                             <p class="mb-1">Filtered using boroughs</p>
-                            <div class="form-group">
+                            <div class="form-group all_boroughs">
+                                <div class="custom-control custom-checkbox">
+                                    <input type="checkbox" class="custom-control-input"
+                                           id="loc_all" name="loc_all"
+                                           {% if search_filter_params.borough.loc_all %}checked=""{% endif %}
+                                    >
+                                    <label class="custom-control-label"
+                                           for="loc_all">All</label>
+                                </div>
+                            </div>
+                            <div class="form-group individual_boroughs">
                                 <div class="custom-control custom-checkbox">
                                     <input type="checkbox" class="custom-control-input"
                                            id="loc_bx" name="loc_bx"
-                                           {% if request.GET.loc_bx %}checked=""{% endif %}
-                                           onchange="search_filter_form.submit();">
+                                           {% if search_filter_params.borough.loc_bx %}checked=""{% endif %}
+                                    >
                                     <label class="custom-control-label"
                                            for="loc_bx">Bronx</label>
                                 </div>
                                 <div class="custom-control custom-checkbox">
                                     <input type="checkbox" class="custom-control-input"
                                            id="loc_bk" name="loc_bk"
-                                           {% if request.GET.loc_bk %}checked=""{% endif %}
-                                           onchange="search_filter_form.submit();">
+                                           {% if search_filter_params.borough.loc_bk %}checked=""{% endif %}
+                                    >
                                     <label class="custom-control-label"
                                            for="loc_bk">Brooklyn</label>
                                 </div>
                                 <div class="custom-control custom-checkbox">
                                     <input type="checkbox" class="custom-control-input"
                                            id="loc_mn" name="loc_mn"
-                                           {% if request.GET.loc_mn %}checked=""{% endif %}
-                                           onchange="search_filter_form.submit();">
+                                           {% if search_filter_params.borough.loc_mn %}checked=""{% endif %}
+                                    >
                                     <label class="custom-control-label"
                                            for="loc_mn">Manhattan</label>
                                 </div>
                                 <div class="custom-control custom-checkbox">
                                     <input type="checkbox" class="custom-control-input"
                                            id="loc_qn" name="loc_qn"
-                                           {% if request.GET.loc_qn %}checked=""{% endif %}
-                                           onchange="search_filter_form.submit();">
+                                           {% if search_filter_params.borough.loc_qn %}checked=""{% endif %}
+                                    >
                                     <label class="custom-control-label"
                                            for="loc_qn">Queens</label>
                                 </div>
                                 <div class="custom-control custom-checkbox">
                                     <input type="checkbox" class="custom-control-input"
                                            id="loc_si" name="loc_si"
-                                           {% if request.GET.loc_si %}checked=""{% endif %}
-                                           onchange="search_filter_form.submit();">
+                                           {% if search_filter_params.borough.loc_si %}checked=""{% endif %}
+                                    >
                                     <label class="custom-control-label"
                                            for="loc_si">Staten Island</label>
                                 </div>

--- a/high_school/templates/high_school/school_list.html
+++ b/high_school/templates/high_school/school_list.html
@@ -2,9 +2,9 @@
     {% load hs_filters %}
     <div style="height: 90%; margin-bottom: 5%;">
         <div class="list-group">
-            <div class="util-div" style="display: flex; flex-direction: row; width: 100%;">
-                <div class="high-school-search">
-                    <form id="search_filter_form" name="search_filter_form" method='GET'>
+            <div class="util-div">
+                <form id="search_filter_form" name="search_filter_form" method='GET'>
+                    <div class="hs-search-filters">
                         <div class="search-div">
                         <span>
                             <input class="search-input" type='text' name='query'
@@ -15,6 +15,19 @@
                             </span>
                         </span>
                         </div>
+                        <div class="filters-div">
+                            <span class="filter-btn"><i class="fa fa-filter"></i></span>
+                            <label class="fav-btn">
+                                <input name="is_fav_on" type="checkbox" class="with-font hide"
+                                       {% if request.GET.is_fav_on %}checked=""{% endif %}
+                                       onchange="search_filter_form.submit();"/>
+                                <i {% if request.GET.is_fav_on %} class="fa fa-heart" {% else %}
+                                                                  class="fa fa-heart-o"{% endif %}>
+                                </i>
+                            </label>
+                        </div>
+                    </div>
+                    <div>
                         <div class="high-school-filter-div">
                             <p class="mb-1">Filter using boroughs</p>
                             <div class="form-group">
@@ -63,21 +76,8 @@
                         <div class="high-school-fav-div {% if not request.GET.is_fav_on or request.GET.is_fav_on == "0" %} hide-fav {% endif %}">
                             <span>These are your favorite schools...</span>
                         </div>
-                    </form>
-                </div>
-                <div class="high-school-filters">
-                    <span class="filter-btn"><i class="fa fa-filter"></i></span>
-                    <form id="fav_form" name="fav_form" method="GET">
-                        <input name="is_fav_on" type="hidden"
-                                {% if not request.GET.is_fav_on or request.GET.is_fav_on == "0" %}
-                               value="1"
-                               {% else %}value="0"{% endif %}>
-                        <span class="fav-btn" onclick="fav_form.submit()"><i
-                                {% if request.GET.is_fav_on and request.GET.is_fav_on == "1" %}
-                                    class="fa fa-heart"{% else %}
-                                    class="fa fa-heart-o" {% endif %}></i></span>
-                    </form>
-                </div>
+                    </div>
+                </form>
             </div>
             {% for school in high_schools %}
                 {% with request.get_full_path as querystring %}
@@ -91,16 +91,20 @@
                 {% endwith %}
             <div class="d-flex w-100 justify-content-between mb-2">
                 <h4 class="mb-1" style="width: 75%">{{ school.school_name }}</h4>
-                <div>
-                <span class="school-fav-btn" dbn_value="{{ school.dbn }}"
-                        {% if school in fav_schools %}
-                      is_fav="1" {% else %} is_fav="0" {% endif %}
-                      style="font-size: 18px; padding: 4px;">
-                <i{% if school in fav_schools %} class="fa fa-heart"{% else %}
-                                                 class="fa fa-heart-o" {% endif %}></i></span>
+                <div class="school-fav-btn">
+                    <form id="favform_{{ school.dbn }}" name="favform_{{ school.dbn }}"
+                          method="POST">
+                        {% csrf_token %}
+                        <label>
+                            <input name="school_fav_on" type="checkbox" class="with-font hide"
+                                   {% if school in fav_schools %}checked=""{% endif %}/>
+                            <i {% if school in fav_schools %} class="fa fa-heart" {% else %}
+                                                              class="fa fa-heart-o"{% endif %}>
+                            </i>
+                        </label>
+                    </form>
                 </div>
             </div>
-            {#TODO: change this to school.boro instead and map it to full name#}
             <div class="d-flex w-100 justify-content-between mb-2">
                 <h5 class="mb-2">{{ school.neighborhood }}</h5>
                 <small class="pt-1"

--- a/high_school/templates/high_school/school_overview.html
+++ b/high_school/templates/high_school/school_overview.html
@@ -3,8 +3,7 @@
         <div class="top-header" style="background: gray">
             <div class="right-pane-container">
                 <h5 class="mb-3" style="font-size: 28px;">{{ selected_school.school_name }}</h5>
-                <h5 class="mb-2">{{ selected_school.neighborhood }}
-                    ({{ selected_school.boro }})</h5>
+                <h5 class="mb-2">{{ selected_school.neighborhood }}</h5>
                 <h6 class="mb-3">{{ selected_school.location|slice:":-23" }}</h6>
                 <h6 class="mb-2">{{ selected_school.total_students }} students</h6>
                 <h6 class="mb-3">
@@ -70,7 +69,10 @@
                                         <span class="mb-3">
                                              {% if program.number_of_seats %}
                                                  {{ program.number_of_seats }} seats
-                                             {% endif %}</span>
+                                             {% else %}
+                                                 Seat info unavailable
+                                             {% endif %}
+                                        </span>
 
                                     </div>
                                     <p class="mb-0">{{ program.description }}</p>
@@ -80,7 +82,7 @@
                     </div>
                 </div>
                 <button class="btn btn-lg btn-outline-primary btn-block"
-                        style="margin: 15% 12.5% 5% 12.5%; width: 75%">More Info
+                        style="margin: 15% 12.5% 5% 12.5%; width: 75%; display: none;">More Info
                 </button>
             </div>
         </div>

--- a/high_school/views.py
+++ b/high_school/views.py
@@ -176,7 +176,7 @@ class HighSchoolListView(ListView):
         self.loc_filter["Q"] = self.request.GET.get("loc_qn")
         self.loc_filter["R"] = self.request.GET.get("loc_si")
         if self.request.GET.get("is_fav_on"):
-            self.is_fav_on = int(self.request.GET.get("is_fav_on"))
+            self.is_fav_on = 1
         else:
             self.is_fav_on = 0
         is_valid_user, temp_user, temp_user_type, temp_context = get_user(self.request)
@@ -229,25 +229,22 @@ class HighSchoolListView(ListView):
                 borough_filter += boro + " , "
         borough_filter = borough_filter[:-3]
 
-        if self.query:
-            if borough_filter:
-                high_schools = HighSchool.objects.filter(
-                    school_name__icontains=self.query, boro__in=borough_filter
-                ).order_by(
-                    "school_name"
-                )  # noqa: E501
-            else:
-                high_schools = HighSchool.objects.filter(
-                    school_name__icontains=self.query
-                ).order_by("school_name")
-        elif borough_filter:
-            high_schools = HighSchool.objects.filter(boro__in=borough_filter).order_by(
-                "school_name"
-            )
-        elif self.is_fav_on and self.is_fav_on == 1:
+        if self.is_fav_on and self.is_fav_on == 1:
             high_schools = self.get_fav_schools()
         else:
             high_schools = HighSchool.objects.order_by("school_name")
+
+        if self.query:
+            if borough_filter and high_schools:
+                high_schools = high_schools.filter(
+                    school_name__icontains=self.query, boro__in=borough_filter
+                ) # noqa: E501
+            elif high_schools:
+                high_schools = high_schools.filter(
+                    school_name__icontains=self.query
+                ).order_by("school_name")
+        elif borough_filter and high_schools:
+            high_schools = high_schools.filter(boro__in=borough_filter)
 
         return high_schools
 
@@ -280,4 +277,4 @@ def update_fav_hs(request, school_dbn, is_fav):
                         user.fav_schools.remove(high_school)
                         user.save()
 
-    return redirect("dashboard:high_school:index")
+    # return redirect("dashboard:high_school:index")

--- a/high_school/views.py
+++ b/high_school/views.py
@@ -53,8 +53,8 @@ def save_high_schools(limit):
             if serializer.initial_data[x]["start_time"]:
                 am_loc = serializer.initial_data[x]["start_time"].find("am")
                 serializer.initial_data[x]["start_time"] = serializer.initial_data[x][
-                                                               "start_time"
-                                                           ][: am_loc + 2]
+                    "start_time"
+                ][: am_loc + 2]
         except KeyError:
             # if there is no start time provided in the info set it to N/A
             serializer.initial_data[x]["start_time"] = "N/A"
@@ -65,8 +65,8 @@ def save_high_schools(limit):
             if serializer.initial_data[x]["end_time"]:
                 pm_loc = serializer.initial_data[x]["end_time"].find("pm")
                 serializer.initial_data[x]["end_time"] = serializer.initial_data[x][
-                                                             "end_time"
-                                                         ][: pm_loc + 2]
+                    "end_time"
+                ][: pm_loc + 2]
         except KeyError:
             # if there is no end time provided in the info set it to N/A
             serializer.initial_data[x]["end_time"] = "N/A"
@@ -94,8 +94,8 @@ def parse_result(result):
         description = "prgdesc" + str(i)
         offer_rate = "offer_rate" + str(i)
         if (
-                result.get(code)
-                and Program.objects.filter(code=result.get(code)).count() == 0
+            result.get(code)
+            and Program.objects.filter(code=result.get(code)).count() == 0
         ):
             # This result is a valid program, and not already in DB save it.
             program = Program()
@@ -302,7 +302,7 @@ class HighSchoolListView(ListView):
         return obj
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 def update_fav_hs(request, school_dbn, is_fav):
     response = {}
     if request.method == "POST":
@@ -319,15 +319,13 @@ def update_fav_hs(request, school_dbn, is_fav):
                 else:
                     user.fav_schools.remove(high_school)
                     user.save()
-                response['status'] = 200
-                response['message'] = "Success"
+                response["status"] = 200
+                response["message"] = "Success"
             else:
-                response['status'] = 403
-                response['message'] = "Forbidden - invalid user"
+                response["status"] = 403
+                response["message"] = "Forbidden - invalid user"
         else:
-            response['status'] = 404
-            response['message'] = "No matching high school found"
-    else:
-        response['status'] = 405
-        response['message'] = "Invalid method type"
+            response["status"] = 404
+            response["message"] = "No matching high school found"
+
     return Response(response)

--- a/static/high_schools/css/high_school.css
+++ b/static/high_schools/css/high_school.css
@@ -100,13 +100,13 @@ body {
 .hs-search-filters .search-div .search-btn {
     color: slategray;
     position: absolute;
-    left: 95%;
+    left: 92%;
     top: 15%;
     cursor: pointer;
 }
 
 .filters-div{
-    margin: 0 2.5% 0 4%;
+    margin-left: 2.5%;
     padding: 2px;
     display: flex;
     font-size: 20px;
@@ -144,7 +144,7 @@ body {
 .filters-div .fav-btn{
     color: slategray;
     cursor: pointer;
-    padding: 0 10px;
+    padding-left: 10px;
 }
 .hide{
     display: none !important;

--- a/static/high_schools/css/high_school.css
+++ b/static/high_schools/css/high_school.css
@@ -110,13 +110,30 @@ body {
     padding: 2px;
     display: flex;
     font-size: 20px;
+    align-items: center;
 }
 
-.filters-div .filter-btn {
+.filters-div .filter-info-div {
+    display: flex;
+    flex-direction: row;
     color: slategray;
     cursor: pointer;
     padding: 0 10px;
 }
+
+.filters-div .filter-action-div{
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.filter-action-div .apply-filters,
+.filter-action-div .cancel-filters{
+    color: slategray;
+    cursor: pointer;
+    padding: 0 10px;
+}
+
 
 .high-school-filter-div {
     display: none;
@@ -127,7 +144,7 @@ body {
 .filters-div .fav-btn{
     color: slategray;
     cursor: pointer;
-    padding-left: 20px;
+    padding: 0 10px;
 }
 .hide{
     display: none !important;

--- a/static/high_schools/css/high_school.css
+++ b/static/high_schools/css/high_school.css
@@ -63,18 +63,27 @@ body {
     width: 100%;
 }
 
-.high-school-search {
-    margin: 2% 2.5% 0 7.5%;
-    width: 75%;
+.util-div{
+    display: flex;
+    flex-direction: column;
+    width: 85%;
+    margin: 2.5% 7.5% 0 7.5% !important;
 }
 
-.high-school-search .search-div {
+.hs-search-filters {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+}
+
+.hs-search-filters .search-div {
     display: flex !important;
     flex-direction: column !important;
     position: relative !important;
+    width: 80%;
 }
 
-.high-school-search .search-div .search-input {
+.hs-search-filters .search-div .search-input {
     width: 100%;
     height: 36px;
     padding: 15px 20px;
@@ -83,12 +92,12 @@ body {
     border-radius: 12px;
 }
 
-.high-school-search .search-div .search-input:focus {
+.hs-search-filters .search-div .search-input:focus {
     outline: none !important;
     border: 2px solid slategray !important;
 }
 
-.high-school-search .search-div .search-btn {
+.hs-search-filters .search-div .search-btn {
     color: slategray;
     position: absolute;
     left: 95%;
@@ -96,14 +105,14 @@ body {
     cursor: pointer;
 }
 
-.high-school-filters{
-    margin: 2% 5% 0 0;
+.filters-div{
+    margin: 0 2.5% 0 4%;
     padding: 2px;
     display: flex;
     font-size: 20px;
 }
 
-.high-school-filters .filter-btn {
+.filters-div .filter-btn {
     color: slategray;
     cursor: pointer;
     padding: 0 10px;
@@ -111,12 +120,12 @@ body {
 
 .high-school-filter-div {
     display: none;
-    margin: 2% 0 0 0;
+    margin-top: 2%;
 }
-.high-school-filters .fav-btn{
+.filters-div .fav-btn{
     color: slategray;
     cursor: pointer;
-    padding: 0 10px;
+    padding-left: 20px;
 }
 .hide-fav{
     display: none;
@@ -138,6 +147,8 @@ body {
 .program-select-div .form-control:focus{
     box-shadow: none !important;
 }
+.hide { display: none; }
+
 /*overriding bootstrap*/
 .list-group-item {
     width: 85% !important;

--- a/static/high_schools/css/high_school.css
+++ b/static/high_schools/css/high_school.css
@@ -121,19 +121,21 @@ body {
 .high-school-filter-div {
     display: none;
     margin-top: 2%;
+    font-size: 16px;
+    color: slategray;
 }
 .filters-div .fav-btn{
     color: slategray;
     cursor: pointer;
     padding-left: 20px;
 }
-.hide-fav{
-    display: none;
+.hide{
+    display: none !important;
 }
 .high-school-fav-div{
-    font-size: 18px;
+    font-size: 16px;
     color: slategray;
-    margin: 2% 0;
+    margin: 2% 0 1% 0;
 }
 .program-div{
     width: fit-content;


### PR DESCRIPTION
Fixed - 
- the more info button is hidden
- user is able to apply filters (including search) and wishlist school together
- if seat info is not there, a generic message conveys unavailability of the information
- by default "all" checkbox is selected since all boroughs are selected by default for viewing
- broken.html to reflect the correct unauth message (the empty-list message was shown earlier as well)

Updated - 
- async update for toggling a particular school fav 
- test cases covering the APIView for toggling fav school

Comments -
- "page shouldn't be refreshed while searching a high school" -> from the understanding of how Django handles templates and views, this functionality might not be possible since the context would continuously need to be updated as the search query is entered. 
- "coming back to the all schools tab, the filters should be saved" -> not sure how to implement this, since the sessions object would continuously be updated as the user interacts with the tab