### PR TITLE
added masking for recommendation url

### DIFF
--- a/OneApply/urls.py
+++ b/OneApply/urls.py
@@ -41,7 +41,7 @@ urlpatterns = [
         name="activate_admission_account",
     ),
     url(
-        r"^recommendation_rating/(?P<uid1>[0-9A-Za-z_\-]+)/$",  # noqa: E501
+        r"^recommendation_rating/(?P<uidb64>[0-9A-Za-z_\-]+)/$",  # noqa: E501
         recommendation_rating,
         name="recommendation_rating",
     ),

--- a/recommendation/templates/recommendation/recommendation_rating.html
+++ b/recommendation/templates/recommendation/recommendation_rating.html
@@ -30,7 +30,7 @@
     {% elif teacher_recommendation %}
     <h3>Teacher Recommendation for <u>{{teacher_recommendation.user.first_name}} {{teacher_recommendation.user.last_name}}</u></h3>
     <h4>Name of Reviewer: {{teacher_recommendation.first_name}} {{teacher_recommendation.last_name}}</h4>
-    <form action="{% url 'recommendation_rating' teacher_recommendation.pk %}" method="post" class="form-signup" style="padding-top: 10px;">
+    <form action="{% url 'recommendation_rating' teacher_pk %}" method="post" class="form-signup" style="padding-top: 10px;">
         {% csrf_token %}
         <div class="rounded bg-secondary" style="height:35px;margin-bottom:10px;">
             <h5 class="p-2">I. Knowledge of Applicant</h5>

--- a/recommendation/templates/recommendation/sent_recommendation_email.html
+++ b/recommendation/templates/recommendation/sent_recommendation_email.html
@@ -2,7 +2,7 @@
 Hi {{ user.first_name }} {{ user.last_name }},
 {{ user.user.first_name}} {{user.user.last_name }} has requested that you fill out a recommendation form for them.
 Please visit the below link to fill out the form:
-http://{{ domain }}{% url 'recommendation_rating' uid1 %}
+http://{{ domain }}{% url 'recommendation_rating' uidb64=uid1 %}
 
 Thank you,
 One Apply Team

--- a/recommendation/urls.py
+++ b/recommendation/urls.py
@@ -7,7 +7,7 @@ app_name = "recommendation"
 urlpatterns = [
     path("add_teacher/", views.new_recommendation, name="new_recommendation"),
     url(
-        r"^recommendation_rating/(?P<uid1>[0-9A-Za-z_\-]+)/$",
+        r"^recommendation_rating/(?P<uidb64>[0-9A-Za-z_\-]+)/$",
         # noqa: E501
         views.recommendation_rating,
         name="recommendation_rating",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.2.6
+Django==2.2.8
 freeze==1.0.10
 pytz==2019.3
 six==1.12.0


### PR DESCRIPTION
I modified the way that the url for recommendations is displayed. 
Previously it would display as:
http://127.0.0.1:8000/recommendation_rating/<ID OF RECOMMENDATION>/

The id of the recommendation is now encoded making it more difficult to manipulate. 